### PR TITLE
Html5

### DIFF
--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -287,10 +287,8 @@ The index, archive, tags, and RSS feed are not updated."
 
 (defun org-static-blog-render-post-content (post-filename)
   "Render blog content as bare HTML without header."
-  (let (
-        (org-html-doctype "html5")
-        (org-html-html5-fancy t)
-        )
+  (let ((org-html-doctype "html5")
+        (org-html-html5-fancy t))
     (org-static-blog-with-find-file
      post-filename
      (org-export-as 'org-static-blog-post-bare nil nil nil nil))))

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -110,7 +110,7 @@ The tags page lists all posts as headlines."
   "HTML to put after the content of each page."
   :group 'org-static-blog)
 
-(defcustom org-static-blog-publish-langcode "en"
+(defcustom org-static-blog-langcode "en"
   "Language code for the blog content."
   :group 'org-static-blog)
 
@@ -260,7 +260,7 @@ The index, archive, tags, and RSS feed are not updated."
    (erase-buffer)
    (insert
     "<!DOCTYPE html>\n"
-    "<html lang=\"" org-static-blog-publish-langcode "\">\n"
+    "<html lang=\"" org-static-blog-langcode "\">\n"
     "<head>\n"
     "<meta charset=\"UTF-8\">\n"
     "<link rel=\"alternate\"\n"
@@ -318,7 +318,7 @@ Posts are sorted in descending time."
    (erase-buffer)
    (insert
     "<!DOCTYPE html>\n"
-    "<html lang=\"" org-static-blog-publish-langcode "\">\n"
+    "<html lang=\"" org-static-blog-langcode "\">\n"
     "<head>\n"
     "<meta charset=\"UTF-8\">\n"
     "<link rel=\"alternate\"\n"
@@ -437,7 +437,7 @@ blog post, but no post body."
      (erase-buffer)
      (insert
       "<!DOCTYPE html>\n"
-      "<html lang=\"" org-static-blog-publish-langcode "\">\n"
+      "<html lang=\"" org-static-blog-langcode "\">\n"
       "<head>\n"
       "<meta charset=\"UTF-8\">\n"
       "<link rel=\"alternate\"\n"
@@ -492,7 +492,7 @@ blog post, sorted by tags, but no post body."
      (erase-buffer)
      (insert
       "<!DOCTYPE html>\n"
-      "<html lang=\"" org-static-blog-publish-langcode "\">\n"
+      "<html lang=\"" org-static-blog-langcode "\">\n"
       "<head>\n"
       "<meta charset=\"UTF-8\">\n"
       "<link rel=\"alternate\"\n"

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -110,6 +110,10 @@ The tags page lists all posts as headlines."
   "HTML to put after the content of each page."
   :group 'org-static-blog)
 
+(defcustom org-static-blog-publish-langcode "en"
+  "Language code for the blog content."
+  :group 'org-static-blog)
+
 ;;;###autoload
 (defun org-static-blog-publish ()
   "Render all blog posts, the index, archive, tags, and RSS feed.
@@ -255,16 +259,14 @@ The index, archive, tags, and RSS feed are not updated."
    (org-static-blog-matching-publish-filename post-filename)
    (erase-buffer)
    (insert
-    "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-    "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
-    "\"https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
-    "<html xmlns=\"https://www.w3.org/1999/xhtml\" lang=\"en\" xml:lang=\"en\">\n"
+    "<!DOCTYPE html>\n"
+    "<html lang=\"" org-static-blog-publish-langcode "\">\n"
     "<head>\n"
-    "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\" />\n"
+    "<meta charset=\"UTF-8\">\n"
     "<link rel=\"alternate\"\n"
     "      type=\"application/rss+xml\"\n"
     "      href=\"" org-static-blog-publish-url org-static-blog-rss-file "\"\n"
-    "      title=\"RSS feed for " org-static-blog-publish-url "\">\n"
+    "      title=\"RSS feed for " org-static-blog-publish-url "\"/>\n"
     "<title>" (org-static-blog-get-title post-filename) "</title>\n"
     org-static-blog-page-header
     "</head>\n"
@@ -285,9 +287,13 @@ The index, archive, tags, and RSS feed are not updated."
 
 (defun org-static-blog-render-post-content (post-filename)
   "Render blog content as bare HTML without header."
-  (org-static-blog-with-find-file
-   post-filename
-   (org-export-as 'org-static-blog-post-bare nil nil nil nil)))
+  (let (
+        (org-html-doctype "html5")
+        (org-html-html5-fancy t)
+        )
+    (org-static-blog-with-find-file
+     post-filename
+     (org-export-as 'org-static-blog-post-bare nil nil nil nil))))
 
 (org-export-define-derived-backend 'org-static-blog-post-bare 'html
   :translate-alist '((template . (lambda (contents info) contents))))
@@ -311,16 +317,14 @@ Posts are sorted in descending time."
    pub-filename
    (erase-buffer)
    (insert
-    "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-    "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\""
-    "\"https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
-    "<html xmlns=\"https://www.w3.org/1999/xhtml\" lang=\"en\" xml:lang=\"en\">\n"
+    "<!DOCTYPE html>\n"
+    "<html lang=\"" org-static-blog-publish-langcode "\">\n"
     "<head>\n"
-    "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\" />\n"
+    "<meta charset=\"UTF-8\">\n"
     "<link rel=\"alternate\"\n"
     "      type=\"appliation/rss+xml\"\n"
     "      href=\"" org-static-blog-publish-url org-static-blog-rss-file "\"\n"
-    "      title=\"RSS feed for " org-static-blog-publish-url "\">\n"
+    "      title=\"RSS feed for " org-static-blog-publish-url "\"/>\n"
     "<title>" org-static-blog-publish-title "</title>\n"
     org-static-blog-page-header
     "</head>\n"
@@ -340,7 +344,8 @@ Posts are sorted in descending time."
     "<a href=\"" org-static-blog-archive-file "\">Other posts</a>\n"
     "</div>\n"
     "</div>\n"
-    "</body>\n")))
+    "</body>\n"
+    "</html>\n")))
 
 (defun org-static-blog-post-preamble (post-filename)
   "Returns the formatted date and headline of the post.
@@ -431,12 +436,10 @@ blog post, but no post body."
      archive-filename
      (erase-buffer)
      (insert
-      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-      "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
-      "\"https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
-      "<html xmlns=\"https://www.w3.org/1999/xhtml\" lang=\"en\" xml:lang=\"en\">\n"
+      "<!DOCTYPE html>\n"
+      "<html lang=\"" org-static-blog-publish-langcode "\">\n"
       "<head>\n"
-      "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\" />\n"
+      "<meta charset=\"UTF-8\">\n"
       "<link rel=\"alternate\"\n"
       "      type=\"appliation/rss+xml\"\n"
       "      href=\"" org-static-blog-publish-url org-static-blog-rss-file "\"\n"
@@ -488,12 +491,10 @@ blog post, sorted by tags, but no post body."
      tags-archive-filename
      (erase-buffer)
      (insert
-      "<?xml version=\"1.0\" encoding=\"utf-8\"?>\n"
-      "<!DOCTYPE html PUBLIC \"-//W3C//DTD XHTML 1.0 Strict//EN\" "
-      "\"https://www.w3.org/TR/xhtml1/DTD/xhtml1-strict.dtd\">\n"
-      "<html xmlns=\"https://www.w3.org/1999/xhtml\" lang=\"en\" xml:lang=\"en\">\n"
+      "<!DOCTYPE html>\n"
+      "<html lang=\"" org-static-blog-publish-langcode "\">\n"
       "<head>\n"
-      "<meta http-equiv=\"Content-Type\" content=\"text/html;charset=utf-8\" />\n"
+      "<meta charset=\"UTF-8\">\n"
       "<link rel=\"alternate\"\n"
       "      type=\"appliation/rss+xml\"\n"
       "      href=\"" org-static-blog-publish-url org-static-blog-rss-file "\"\n"


### PR DESCRIPTION
This patch generates valid HTML5 according to 

https://validator.w3.org/

The Org Mode exporter is also set to use HTML5 with org-html-doctype and to use the new HTML5 keyword, if used. That is, a

```
#+BEGIN_aside
Lorem ipsum
#+END_aside
```

generates

```
<aside>
Lorem ipsum
</aside>
```
et cetera.

No div's where touched. All existing stylesheets should continue to work.

Adds a new customizable variable, `org-static-blog-langcode` to indicate the content language.
