### PR TITLE
make filetags rss categories

### DIFF
--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -208,6 +208,16 @@ existed before)."
 	  (date-to-time (match-string 1))
 	(time-since 0)))))
 
+(defun org-static-blog-get-filetags (post-filename)
+  "Extract the `#+filetags:` from POST-FILENAME as list of strings."
+  (let ((case-fold-search t))
+    (with-temp-buffer
+      (insert-file-contents post-filename)
+      (goto-char (point-min))
+      (if (search-forward-regexp "^\\#\\+filetags:[ ]*:\\(.*\\):$" nil t)
+          (split-string (match-string 1) ":")
+	))))
+
 (defun org-static-blog-get-title (post-filename)
   "Extract the `#+title:` from POST-FILENAME."
   (let ((case-fold-search t))
@@ -425,7 +435,7 @@ machine-readable format."
 	     "<lastBuildDate>" (format-time-string "%a, %d %b %Y %H:%M:%S %z" (current-time)) "</lastBuildDate>\n"
 	     (apply 'concat (mapcar 'cdr rss-items))
 	     "</channel>\n"
-             "</rss>\n"))))
+	     "</rss>\n"))))
 
 (defun org-static-blog-get-rss-item (post-filename)
   "Assemble RSS item from post-filename.
@@ -433,6 +443,8 @@ The HTML content is taken from the rendered HTML post."
   (concat
    "<item>\n"
    "  <title>" (org-static-blog-get-title post-filename) "</title>\n"
+   (mapconcat (lambda (tag) (format "<category>%s</category>" tag))
+	      (org-static-blog-get-filetags post-filename) "\n")
    "  <description><![CDATA["
    (org-static-blog-get-body post-filename t) ; exclude headline!
    "]]></description>\n"

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -208,16 +208,6 @@ existed before)."
 	  (date-to-time (match-string 1))
 	(time-since 0)))))
 
-(defun org-static-blog-get-filetags (post-filename)
-  "Extract the `#+filetags:` from POST-FILENAME as list of strings."
-  (let ((case-fold-search t))
-    (with-temp-buffer
-      (insert-file-contents post-filename)
-      (goto-char (point-min))
-      (if (search-forward-regexp "^\\#\\+filetags:[ ]*:\\(.*\\):$" nil t)
-          (split-string (match-string 1) ":")
-	))))
-
 (defun org-static-blog-get-title (post-filename)
   "Extract the `#+title:` from POST-FILENAME."
   (let ((case-fold-search t))
@@ -443,8 +433,11 @@ The HTML content is taken from the rendered HTML post."
   (concat
    "<item>\n"
    "  <title>" (org-static-blog-get-title post-filename) "</title>\n"
-   (mapconcat (lambda (tag) (format "<category>%s</category>" tag))
-	      (org-static-blog-get-filetags post-filename) "\n")
+   (let ((post-tags (org-static-blog-get-tags post-filename)))
+     (when post-tags
+       (mapconcat (lambda (tag) (when (not (string= tag ""))
+				  (format "<category>%s</category>" tag)))
+		  (split-string (car post-tags) ":") "\n")))
    "  <description><![CDATA["
    (org-static-blog-get-body post-filename t) ; exclude headline!
    "]]></description>\n"

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -423,11 +423,6 @@ The HTML content is taken from the rendered HTML post."
   (concat
    "<item>\n"
    "  <title>" (org-static-blog-get-title post-filename) "</title>\n"
-   (let ((post-tags (org-static-blog-get-tags post-filename)))
-     (when post-tags
-       (mapconcat (lambda (tag) (when (not (string= tag ""))
-				  (format "<category>%s</category>" tag)))
-		  post-tags "\n")))
    "  <description><![CDATA["
    (org-static-blog-get-body post-filename t) ; exclude headline!
    "]]></description>\n"

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -223,21 +223,11 @@ existed before)."
     (with-temp-buffer
       (insert-file-contents post-filename)
       (goto-char (point-min))
-      (if (search-forward-regexp "^\\#\\+filetags:[ ]*\\(.+\\)$" nil t)
-          (split-string (match-string 1))
-        ;; for a very short time, I allowed #+tags: to be used to set
-        ;; tags. This was wrong. It now still works, but will issue a
-        ;; warning, and will be removed in the future.
-        (if (search-forward-regexp "^\\#\\+tags:[ ]*\\(.+\\)$" nil t)
-            (progn
-              (if org-static-blog-enable-deprecation-warning
-                  (display-warning
-                   :warning
-                   (concat "Using `#+tags:` is deprecated and "
-                           "will be removed in the future. "
-                           "Please use `#+filetags` instead")))
-              (split-string (match-string 1)))
-          nil)))))
+      (if (search-forward-regexp "^\\#\\+filetags:[ ]*:\\(.*\\):$" nil t)
+          (split-string (match-string 1) ":")
+	(if (search-forward-regexp "^\\#\\+filetags:[ ]*\\(.+\\)$" nil t)
+            (split-string (match-string 1))
+	  )))))
 
 (defun org-static-blog-get-tag-tree ()
   "Return an association list of tags to filenames.
@@ -437,7 +427,7 @@ The HTML content is taken from the rendered HTML post."
      (when post-tags
        (mapconcat (lambda (tag) (when (not (string= tag ""))
 				  (format "<category>%s</category>" tag)))
-		  (split-string (car post-tags) ":") "\n")))
+		  post-tags "\n")))
    "  <description><![CDATA["
    (org-static-blog-get-body post-filename t) ; exclude headline!
    "]]></description>\n"


### PR DESCRIPTION
This allows consumers of blogs via RSS to filter on filetags on posts.

validated output on https://validator.w3.org/feed/#validate_by_input