### PR TITLE
Implement support for non-flat directory structure

### DIFF
--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -374,8 +374,8 @@ If this function is overriden with something like this:
           \"/\"
           (file-name-nondirectory post-filename)))
 
-Then the output will be '2019/08/20/charity-coding.html' and this will be
-the path to HTML file in publish directory and the url for the post."
+Then the output will be '2019/08/20/charity-coding' and this will be
+the path to the HTML file in publish directory and the url for the post."
   post-filename)
 
 ;;;###autoload

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -313,8 +313,11 @@ Preamble and Postamble are excluded, too."
   "Cleanup and normalize POST-FILENAME to be sent to user-defined function"
   (replace-regexp-in-string ".org$" ""
    (replace-regexp-in-string
-    (concat "^"
-            (file-truename org-static-blog-posts-directory))
+    (concat "^\\("
+            (file-truename org-static-blog-posts-directory)
+            "\\|"
+            (file-truename org-static-blog-drafts-directory)
+            "\\)")
     ""
     post-filename)))
 

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -320,7 +320,7 @@ Preamble and Postamble are excluded, too."
 
 (defun org-static-blog-post-url (post-filename post-datetime)
   "Generate arbitrary post URL. This function is overridable by user"
-  ('post-filename))
+  post-filename)
 
 ;;;###autoload
 (defun org-static-blog-publish-file (post-filename)

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -349,7 +349,7 @@ will return 'my-life-update.html'."
                              post-filename)))
 
 (defun org-static-blog-generate-post-path (post-filename post-datetime)
-  "Returns post public path based on POST-FILENAME and PORT-DATETIME.
+  "Returns post public path based on POST-FILENAME and POST-DATETIME.
 
 By default, this function returns post filepath unmodified, so script will
 replicate file and directory structure of posts and drafts directories.

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -432,7 +432,7 @@ Modify this function if you want to change a posts headline."
 						   (org-static-blog-get-date post-filename))
    "</div>"
    "<h1 class=\"post-title\">"
-   "<a href=\"" (org-static-blog-get-url post-filename) "\">" (org-static-blog-get-title post-filename) "</a>"
+   "<a href=\"" org-static-blog-publish-url (org-static-blog-get-url post-filename) "\">" (org-static-blog-get-title post-filename) "</a>"
    "</h1>\n"))
 
 (defun org-static-blog-post-postamble (post-filename)
@@ -548,7 +548,7 @@ archive headline."
    (format-time-string (org-static-blog-gettext 'date-format) (org-static-blog-get-date post-filename))
    "</div>"
    "<h2 class=\"post-title\">"
-   "<a href=\"" (org-static-blog-get-url post-filename) "\">" (org-static-blog-get-title post-filename) "</a>"
+   "<a href=\"" org-static-blog-publish-url (org-static-blog-get-url post-filename) "\">" (org-static-blog-get-title post-filename) "</a>"
    "</h2>\n"))
 
 (defun org-static-blog-assemble-tags ()

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -303,22 +303,41 @@ Preamble and Postamble are excluded, too."
        (point)))))
 
 (defun org-static-blog-get-absolute-url (relative-url)
-  "Return absolute URL based on the RELATIVE-URL passed to the function."
+  "Returns absolute URL based on the RELATIVE-URL passed to the function.
+
+For example, when `org-static-blog-publish-url` is set to 'https://example.com/'
+and `relative-url` is passed as 'archive.html' then the function
+will return 'https://example.com/archive.html'."
   (concat org-static-blog-publish-url relative-url))
 
 (defun org-static-blog-get-post-url (post-filename)
-  "Generate full URL to the published POST-FILENAME."
+  "Returns absolute URL to the published POST-FILENAME.
+
+This function concatenates publish URL and generated custom filepath to the
+published HTML version of the post."
   (org-static-blog-get-absolute-url
           (org-static-blog-get-post-public-path post-filename)))
 
 (defun org-static-blog-get-post-public-path (post-filename)
-  "Return post filepath in public directory."
+  "Returns post filepath in public directory.
+
+This function retrieves relative path to the post file in posts or drafts
+directories, the date of the post from its contents and then passes it to
+`org-static-blog-generate-post-path` to generate custom filepath for the published
+HTML version of the post."
   (org-static-blog-generate-post-path
    (org-static-blog-get-relative-path post-filename)
    (org-static-blog-get-date post-filename)))
 
 (defun org-static-blog-get-relative-path (post-filename)
-  "Remove absolute directory path from POST-FILENAME and return relative path to HTML file."
+  "Removes absolute directory path from POST-FILENAME and changes file extention
+from `.org` to `.html`. Returns filepath to HTML file relative to posts or drafts directories.
+
+Works with both posts and drafts directories.
+
+For example, when `org-static-blog-posts-directory` is set to '~/blog/posts'
+and `post-filename` is passed as '~/blog/posts/my-life-update.org' then the function
+will return 'my-life-update.html'."
   (replace-regexp-in-string ".org$" ".html"
                             (replace-regexp-in-string
                              (concat "^\\("
@@ -330,8 +349,33 @@ Preamble and Postamble are excluded, too."
                              post-filename)))
 
 (defun org-static-blog-generate-post-path (post-filename post-datetime)
-  "Generate post public path (URL) based on POST-FILENAME and PORT-DATETIME.
-This function is overridable by user."
+  "Returns post public path based on POST-FILENAME and PORT-DATETIME.
+
+By default, this function returns post filepath unmodified, so script will
+replicate file and directory structure of posts and drafts directories.
+
+Override this function if you want to generate custom post URLs different
+from how they are stored in posts and drafts directories.
+
+For example, there is a post in posts directory with the
+file path `hobby/charity-coding.org` and dated `<2019-08-20 Tue>`.
+
+In this case, the function will receive following argument values:
+- post-filename: 'hobby/charity-coding'
+- post-datetime: datetime of <2019-08-20 Tue>
+
+and by default will return 'hobby/charity-coding', so that the path
+to HTML file in publish directory will be 'hobby/charity-coding.html'.
+
+If this function is overriden with something like this:
+
+(defun org-static-blog-generate-post-path (post-filename post-datetime)
+  (concat (format-time-string \"%Y/%m/%d\" post-datetime)
+          \"/\"
+          (file-name-nondirectory post-filename)))
+
+Then the output will be '2019/08/20/charity-coding.html' and this will be
+the path to HTML file in publish directory and the url for the post."
   post-filename)
 
 ;;;###autoload

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -197,22 +197,22 @@ re-rendered."
 (defun org-static-blog-matching-publish-filename (post-filename)
   "Generate HTML file name for POST-FILENAME."
   (concat org-static-blog-publish-directory
-          (file-name-base post-filename)
-          ".html"))
+          (org-static-blog-get-url post-filename)))
 
 (defun org-static-blog-get-post-filenames ()
   "Returns a list of all posts."
-  (directory-files
-   org-static-blog-posts-directory t ".*\\.org$" nil))
+  (directory-files-recursively
+   org-static-blog-posts-directory ".*\\.org$"))
 
 (defun org-static-blog-get-draft-filenames ()
   "Returns a list of all drafts."
-  (directory-files
-   org-static-blog-drafts-directory t ".*\\.org$" nil))
+  (directory-files-recursively
+   org-static-blog-drafts-directory ".*\\.org$"))
 
 (defun org-static-blog-file-buffer (file)
   "Return the buffer open with a full filepath, or nil."
   (require 'seq)
+  (make-directory (file-name-directory file) t)
   (car (seq-filter
          (lambda (buf)
            (string= (with-current-buffer buf buffer-file-name) file))
@@ -304,8 +304,10 @@ Preamble and Postamble are excluded, too."
 
 (defun org-static-blog-get-url (post-filename)
   "Generate a URL to the published POST-FILENAME."
-  (file-name-nondirectory
-   (org-static-blog-matching-publish-filename post-filename)))
+  (replace-regexp-in-string ".org$" ".html"
+   (replace-regexp-in-string
+    (concat "^" (file-truename org-static-blog-posts-directory))
+     "" post-filename)))
 
 ;;;###autoload
 (defun org-static-blog-publish-file (post-filename)

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -417,7 +417,7 @@ Posts are sorted in descending time."
     (when front-matter front-matter)
     (apply 'concat (mapcar 'org-static-blog-get-body post-filenames))
     "<div id=\"archive\">\n"
-    "<a href=\"" org-static-blog-archive-file "\">" (org-static-blog-gettext 'other-posts) "</a>\n"
+    "<a href=\"" org-static-blog-publish-url org-static-blog-archive-file "\">" (org-static-blog-gettext 'other-posts) "</a>\n"
     "</div>\n"
     "</div>\n"
     "</body>\n"
@@ -443,10 +443,12 @@ Modify this function if you want to change a posts footline."
     (when (and (org-static-blog-get-tags post-filename) org-static-blog-enable-tags)
       (setq taglist-content (concat "<div class=\"taglist\">"
                                     "<a href=\""
+                                    org-static-blog-publish-url
                                     org-static-blog-tags-file
                                     "\">" (org-static-blog-gettext 'tags) "</a>: "))
       (dolist (tag (org-static-blog-get-tags post-filename))
         (setq taglist-content (concat taglist-content "<a href=\""
+                                      org-static-blog-publish-url
                                       "tag-" (downcase tag) ".html"
                                       "\">" tag "</a> ")))
       (setq taglist-content (concat taglist-content "</div>")))

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -302,13 +302,13 @@ Preamble and Postamble are excluded, too."
        (search-backward "</div>")
        (point)))))
 
-(defun org-static-blog-get-full-url (relative-url)
+(defun org-static-blog-get-absolute-url (relative-url)
   "Return absolute URL based on the RELATIVE-URL passed to the function."
   (concat org-static-blog-publish-url relative-url))
 
 (defun org-static-blog-get-post-url (post-filename)
   "Generate full URL to the published POST-FILENAME."
-  (org-static-blog-get-full-url
+  (org-static-blog-get-absolute-url
           (org-static-blog-get-post-public-path post-filename)))
 
 (defun org-static-blog-get-post-public-path (post-filename)
@@ -348,7 +348,7 @@ The index, archive, tags, and RSS feed are not updated."
     "<meta charset=\"UTF-8\">\n"
     "<link rel=\"alternate\"\n"
     "      type=\"application/rss+xml\"\n"
-    "      href=\"" (org-static-blog-get-full-url org-static-blog-rss-file) "\"\n"
+    "      href=\"" (org-static-blog-get-absolute-url org-static-blog-rss-file) "\"\n"
     "      title=\"RSS feed for " org-static-blog-publish-url "\"/>\n"
     "<title>" (org-static-blog-get-title post-filename) "</title>\n"
     org-static-blog-page-header
@@ -416,7 +416,7 @@ Posts are sorted in descending time."
     "<meta charset=\"UTF-8\">\n"
     "<link rel=\"alternate\"\n"
     "      type=\"application/rss+xml\"\n"
-    "      href=\"" (org-static-blog-get-full-url org-static-blog-rss-file) "\"\n"
+    "      href=\"" (org-static-blog-get-absolute-url org-static-blog-rss-file) "\"\n"
     "      title=\"RSS feed for " org-static-blog-publish-url "\"/>\n"
     "<title>" org-static-blog-publish-title "</title>\n"
     org-static-blog-page-header
@@ -429,7 +429,7 @@ Posts are sorted in descending time."
     (when front-matter front-matter)
     (apply 'concat (mapcar 'org-static-blog-get-body post-filenames))
     "<div id=\"archive\">\n"
-    "<a href=\"" (org-static-blog-get-full-url org-static-blog-archive-file) "\">" (org-static-blog-gettext 'other-posts) "</a>\n"
+    "<a href=\"" (org-static-blog-get-absolute-url org-static-blog-archive-file) "\">" (org-static-blog-gettext 'other-posts) "</a>\n"
     "</div>\n"
     "</div>\n"
     "</body>\n"
@@ -455,11 +455,11 @@ Modify this function if you want to change a posts footline."
     (when (and (org-static-blog-get-tags post-filename) org-static-blog-enable-tags)
       (setq taglist-content (concat "<div class=\"taglist\">"
                                     "<a href=\""
-                                    (org-static-blog-get-full-url org-static-blog-tags-file)
+                                    (org-static-blog-get-absolute-url org-static-blog-tags-file)
                                     "\">" (org-static-blog-gettext 'tags) "</a>: "))
       (dolist (tag (org-static-blog-get-tags post-filename))
         (setq taglist-content (concat taglist-content "<a href=\""
-                                      (org-static-blog-get-full-url (concat "tag-" (downcase tag) ".html"))
+                                      (org-static-blog-get-absolute-url (concat "tag-" (downcase tag) ".html"))
                                       "\">" tag "</a> ")))
       (setq taglist-content (concat taglist-content "</div>")))
     taglist-content))
@@ -530,7 +530,7 @@ blog post, but no post body."
       "<meta charset=\"UTF-8\">\n"
       "<link rel=\"alternate\"\n"
       "      type=\"application/rss+xml\"\n"
-      "      href=\"" (org-static-blog-get-full-url org-static-blog-rss-file) "\"\n"
+      "      href=\"" (org-static-blog-get-absolute-url org-static-blog-rss-file) "\"\n"
       "      title=\"RSS feed for " org-static-blog-publish-url "\">\n"
       "<title>" org-static-blog-publish-title "</title>\n"
       org-static-blog-page-header
@@ -592,7 +592,7 @@ blog post, sorted by tags, but no post body."
       "<meta charset=\"UTF-8\">\n"
       "<link rel=\"alternate\"\n"
       "      type=\"application/rss+xml\"\n"
-      "      href=\"" (org-static-blog-get-full-url org-static-blog-rss-file) "\"\n"
+      "      href=\"" (org-static-blog-get-absolute-url org-static-blog-rss-file) "\"\n"
       "      title=\"RSS feed for " org-static-blog-publish-url "\">\n"
       "<title>" org-static-blog-publish-title "</title>\n"
       org-static-blog-page-header

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -304,10 +304,23 @@ Preamble and Postamble are excluded, too."
 
 (defun org-static-blog-get-url (post-filename)
   "Generate a URL to the published POST-FILENAME."
-  (replace-regexp-in-string ".org$" ".html"
+  (concat (org-static-blog-post-url
+           (org-static-blog-prepare-post-url post-filename)
+           (org-static-blog-get-date post-filename))
+          ".html"))
+
+(defun org-static-blog-prepare-post-url (post-filename)
+  "Cleanup and normalize POST-FILENAME to be sent to user-defined function"
+  (replace-regexp-in-string ".org$" ""
    (replace-regexp-in-string
-    (concat "^" (file-truename org-static-blog-posts-directory))
-     "" post-filename)))
+    (concat "^"
+            (file-truename org-static-blog-posts-directory))
+    ""
+    post-filename)))
+
+(defun org-static-blog-post-url (post-filename post-datetime)
+  "Generate arbitrary post URL. This function is overridable by user"
+  ('post-filename))
 
 ;;;###autoload
 (defun org-static-blog-publish-file (post-filename)


### PR DESCRIPTION
Hi there,

Would love to hear your feedback / code review as this is my first public elisp code.

The implementation already supports nested directories for drafts/posts.
However, I am still thinking of the best approach to develop @neeasade 's idea of having a separate function to generate URLs.
At the moment user can re-define `org-static-blog-get-url` to achieve that, but I believe it would be better to split this function into two: one that does necessary changes to the file path (e.g. changing `.org` to `.html`) and another to generate the rest of the URL path. The second one should be overridable.

Related to issue #10