### PR TITLE
fix wrong relative path

### DIFF
--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -433,7 +433,7 @@ will return 'my-life-update.html'."
                                      (file-truename org-static-blog-drafts-directory)
                                      "\\)")
                              ""
-                             post-filename)))
+                             (file-truename post-filename))))
 
 (defun org-static-blog-generate-post-path (post-filename post-datetime)
   "Returns post public path based on POST-FILENAME and POST-DATETIME.

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -425,15 +425,7 @@ Works with both posts and drafts directories.
 For example, when `org-static-blog-posts-directory` is set to '~/blog/posts'
 and `post-filename` is passed as '~/blog/posts/my-life-update.org' then the function
 will return 'my-life-update.html'."
-  (replace-regexp-in-string ".org$" ".html"
-                            (replace-regexp-in-string
-                             (concat "^\\("
-                                     (file-truename org-static-blog-posts-directory)
-                                     "\\|"
-                                     (file-truename org-static-blog-drafts-directory)
-                                     "\\)")
-                             ""
-                             post-filename)))
+  (concat (file-name-base post-filename) ".html"))
 
 (defun org-static-blog-generate-post-path (post-filename post-datetime)
   "Returns post public path based on POST-FILENAME and POST-DATETIME.

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -425,7 +425,15 @@ Works with both posts and drafts directories.
 For example, when `org-static-blog-posts-directory` is set to '~/blog/posts'
 and `post-filename` is passed as '~/blog/posts/my-life-update.org' then the function
 will return 'my-life-update.html'."
-  (concat (file-name-base post-filename) ".html"))
+  (replace-regexp-in-string ".org$" ".html"
+                            (replace-regexp-in-string
+                             (concat "^\\("
+                                     (file-truename org-static-blog-posts-directory)
+                                     "\\|"
+                                     (file-truename org-static-blog-drafts-directory)
+                                     "\\)")
+                             ""
+                             post-filename)))
 
 (defun org-static-blog-generate-post-path (post-filename post-datetime)
   "Returns post public path based on POST-FILENAME and POST-DATETIME.


### PR DESCRIPTION
replace-regexp-in-string do not work properly. 
when post-filename start with "~/...", (file-truename post-filename) would return "/home/$user/..." which not match post-filename.