### PR TITLE
Pointer to https://jao.io, another blog using org-static-blog

### DIFF
--- a/README.org
+++ b/README.org
@@ -145,6 +145,7 @@ Other org-static-blog blogs:
 - [[https://zngguvnf.org/][zngguvnf.org]]
 - [[https://matthewbauer.us/blog/][matthewbauer.us/blog/]]
 - [[http://lisper.pl/][lisper.pl]]
+- [[https://jao.io/blog/2020-02-11-simplicity.html][jao's programming musings]]
 - Please open a pull request to add your blog, here!
 
 * Known Issues


### PR DESCRIPTION
The links points concretely to a post where i explain how i set it up.