### PR TITLE
Optional extra information to be added in the RSS

### DIFF
--- a/README.org
+++ b/README.org
@@ -58,6 +58,12 @@ ways:
   blog post. If you want to change the formatting of dates, titles, or
   the tag list, overwrite these functions.
 
+You    can    customize   the    RSS    feed    output   by    setting
+=org-static-blog-rss-extra=. Its  content is  placed right  before the
+sequence of posts. For  example you can add an RSS  icon for the feed,
+or advertise that you built your blog with org-static-blog.
+
+
 There are some static texts like "/Other posts/", "/Tags/" etc that
 org-static-blog includes in produced html. By default org-static-blog
 uses english texts, but language chosen depends on value set to

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -111,6 +111,16 @@ The tags page lists all posts as headlines."
   :group 'org-static-blog
   :safe t)
 
+(defcustom org-static-blog-rss-extra ""
+  "Extra information for the RSS feed header.
+This information is placed right before the sequence of posts.
+You can add an icon for the feed, or advertise that you built
+your blog with emacs, org-mode and org-static-blog.
+"
+  :group 'org-static-blog
+  :safe t)
+
+
 (defcustom org-static-blog-page-header ""
   "HTML to put in the <head> of each page."
   :group 'org-static-blog
@@ -619,6 +629,7 @@ machine-readable format."
 	     "<description><![CDATA[" org-static-blog-publish-title "]]></description>\n"
 	     "<link>" org-static-blog-publish-url "</link>\n"
 	     "<lastBuildDate>" (format-time-string "%a, %d %b %Y %H:%M:%S %z" (current-time)) "</lastBuildDate>\n"
+             org-static-blog-rss-extra
 	     (apply 'concat (mapcar 'cdr rss-items))
 	     "</channel>\n"
 	     "</rss>\n"))))


### PR DESCRIPTION
It is useful to add extra information in the RSS feed so I added a variable `org-static-blog-rss-extra`which value is the empty string by default, and that I set in this way  

```
(setq org-static-blog-rss-extra
      (concat
       "<generator>"
       (format "Emacs %d.%d" emacs-major-version emacs-minor-version) " "
       "Org-mode " (org-version) " "
       "org-static-blog 1.3.0"
       "</generator>\n"
       "<webMaster>" user-full-name " (" user-mail-address ") " "</webMaster>\n" 
       "<image>\n"
       "<url>" org-static-blog-publish-url "favicon.ico" "</url>\n"
       "<title>" org-static-blog-publish-title "</title>\n" 
       "<link>" org-static-blog-publish-url "</link>\n"
       "</image>\n"))
```