### PR TITLE
Keep post-date below post-title

### DIFF
--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -607,12 +607,12 @@ Posts are sorted in descending time."
 This function is called for every post and prepended to the post body.
 Modify this function if you want to change a posts headline."
   (concat
-   "<div class=\"post-date\">" (format-time-string (org-static-blog-gettext 'date-format)
-						   (org-static-blog-get-date post-filename))
-   "</div>"
    "<h1 class=\"post-title\">"
    "<a href=\"" (org-static-blog-get-post-url post-filename) "\">" (org-static-blog-get-title post-filename) "</a>"
-   "</h1>\n"))
+   "</h1>\n"
+   "<div class=\"post-date\">" (format-time-string (org-static-blog-gettext 'date-format)
+						   (org-static-blog-get-date post-filename))
+   "</div>\n"))
 
 
 (defun org-static-blog-post-taglist (post-filename)
@@ -719,12 +719,12 @@ This function is called for every post on the archive and
 tags-archive page. Modify this function if you want to change an
 archive headline."
   (concat
-   "<div class=\"post-date\">"
-   (format-time-string (org-static-blog-gettext 'date-format) (org-static-blog-get-date post-filename))
-   "</div>"
    "<h2 class=\"post-title\">"
    "<a href=\"" (org-static-blog-get-post-url post-filename) "\">" (org-static-blog-get-title post-filename) "</a>"
-   "</h2>\n"))
+   "</h2>\n"
+   "<div class=\"post-date\">"
+   (format-time-string (org-static-blog-gettext 'date-format) (org-static-blog-get-date post-filename))
+   "</div>\n"))
 
 (defun org-static-blog-assemble-tags ()
   "Render the tag archive and tag pages."


### PR DESCRIPTION
The idea is work with classes css libraries. In any classes css library the headings have a very huge top margin. This generally pushes the date away, making stuff look very ugly.

So, this is basically a simple solution to that. This does not deviate from a common structure too much so is a decent solution.

In the future, we should have a few template options that decide the structure of elements for building up web pages. Once I properly document a satisfactory idea I can send a PR.

Note: This PR is based on a personal opinion. This might not even be the best web practice. If you feel this is unecessary, feel free to close the PR.