### PR TITLE
temporarily disable auto-insert-mode when creating HTML files

### DIFF
--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -435,6 +435,7 @@ existed before)."
      (let ((current-buffer (current-buffer))
            (buffer-exists (org-static-blog-file-buffer ,file))
            (result nil)
+           (auto-insert nil)
 	   (contents ,contents))
        (if buffer-exists
            (switch-to-buffer buffer-exists)


### PR DESCRIPTION
auto-insert-mode is a minor mode which automatically inserts text whenever find-file creates a new file.  It's used for license statements and boilerplate "skeleton code".

In the case of HTML files, it will prompt the user for a webpage title then write in a skeleton HTML file.  This interferes with org-static-blog.

The solution is to temporarily set auto-insert to nil when opening a new file.  This tells auto-insert-mode to stay out of our way.