### PR TITLE
remove potentially malicious site link

### DIFF
--- a/README.org
+++ b/README.org
@@ -196,7 +196,6 @@ your problem right now/. Please be civil.
     - [[https://alhassy.github.io/][Life & Computing Science]]
       * Clickable headlines, banner, floating toc, Disqus comments, styling, ..., see the [[https://alhassy.github.io/AlBasmala][writeup]]
     - [[https://xgqt.gitlab.io/blog/][xgqt.gitlab.io/blog]]
-    - [[https://wangz.me][wangz.me]]
     - [[https://justin.abrah.ms/][Justin Abrahms]]
     - Please open a pull request to add your blog, here!
 


### PR DESCRIPTION
This link in the README no longer points to a blog, and instead goes to a domain-squatting page. When I checked a few days ago, it went through a series of redirects before arriving at a porn/scam site.