### PR TITLE
Fix #131: update regexp to support inactive date timestamp.

### DIFF
--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -499,7 +499,7 @@ existed before)."
     (with-temp-buffer
       (insert-file-contents post-filename)
       (goto-char (point-min))
-      (if (search-forward-regexp "^\\#\\+date:[ ]*<\\([^]>]+\\)>$" nil t)
+      (if (search-forward-regexp "^\\#\\+date:[ ]*[[<]?\\([^]>]+\\)[]>]?$" nil t)
 	  (date-to-time (match-string 1))
 	(time-since 0)))))
 


### PR DESCRIPTION
Hello, I update `org-static-blog-get-date` according to your suggestion. I am very glad to have it work in my settings. Thank you.