### PR TITLE
Update README.org's list of blogs that use org-stastic-blog

### DIFF
--- a/README.org
+++ b/README.org
@@ -197,18 +197,11 @@ your problem right now/. Please be civil.
    use =org-static-blog= in practice.
 
 *** Other org-static-blog blogs:
-    - [[http://cat-v.mit.edu/][cat-v.mit.edu]]
-    - [[https://zngguvnf.org/][zngguvnf.org]]
+    - [[https://zngguvnf.org/][zngguvnf.org]] ---see the [[https://zngguvnf.org/2017-07-13--blogging-with-org-static-blog.html][writeup]]
     - [[https://matthewbauer.us/blog/][matthewbauer.us/blog/]]
-    - [[http://lisper.pl/][lisper.pl]]
-    - [[https://jao.io/blog/2020-02-11-simplicity.html][jao's programming musings]]
-    - [[https://whatacold.github.io/][whatacold.github.io]]
-    - [[https://massimolauria.net/blog/][Hard Theorems]]
+    - [[https://jao.io/][jao's programming musings]]
     - [[https://f-santos.gitlab.io/][f-santos.gitlab.io]]
-    - [[https://alhassy.github.io/][Life & Computing Science]]
-      * Clickable headlines, banner, floating toc, Disqus comments, styling, ..., see the [[https://alhassy.github.io/AlBasmala][writeup]]
     - [[https://xgqt.gitlab.io/blog/][xgqt.gitlab.io/blog]]
-    - [[https://justin.abrah.ms/][Justin Abrahms]]
     - [[https://unmonoqueteclea.github.io/][unmonoqueteclea]]
     - Please open a pull request to add your blog, here!
 


### PR DESCRIPTION
Below is the rationale for what was removed.

- http://cat-v.mit.edu/ ⭆ Does not open

- https://matthewbauer.us/blog/ ⭆ Not sure if this uses org-static-blog anymore

- http://lisper.pl/ ⭆ This is a ceramics company website, it does not look like it uses org-static-blog anymore

- https://jao.io/blog/2020-02-11-simplicity.html ⭆ Does not open; but https://jao.io/ works. Verified this still uses org-static-blog.

- https://whatacold.github.io/ ⭆ The footer says “Hugo Powered”, which I assume means it does not use org-static-blog anymore?

- https://massimolauria.net/blog/ ⭆ Does not open

- https://alhassy.github.io (mine) ⭆ Redefines so much of org-static-blog that it seems to only use org-static-blog for generating RSS, and I suspect that will be dropped soon and so there wont be any dependency on org-static-blog. (Nonetheless, thanks for making the package! 💝)

- https://xgqt.gitlab.io/blog ⭆ The footer says “Site generated by Frog, the frozen blog tool. Using Bootstrap.”, which I assume means it does not use org-static-blog anymore?

- https://justin.abrah.ms/ ⭆ This uses the Hugo theme Simpleness, which I assume means it does not use org-static-blog anymore?