### PR TITLE
Add comments via Mastodon with Emfed?

### DIFF
--- a/emfed-config-example.el
+++ b/emfed-config-example.el
@@ -1,0 +1,8 @@
+(setq org-static-blog-emfed-comments-block 
+      "<div id=\"comments\"><h2>Comments<h2></div>
+       <a class=\"mastodon-thread\" target=\"_blank\"
+          href=\"https://emacs.ch/@jameshowell/%s\"
+          data-toot-id=\"%s\"
+          data-exclude-post=\"true\"
+          >Turn on JavaScript to view comments, or follow this link to the Mastodon thread</a>
+       <p>You can <a target=\"_blank\" href=\"https://emacs.ch/@jameshowell/%s\">add a comment on Mastodon</a>.</p>")

--- a/emfed-config-example.el
+++ b/emfed-config-example.el
@@ -1,3 +1,6 @@
+(setq org-static-blog-page-header
+        "<script type=\"module\" src=\"https://esm.sh/emfed@\"></script>")
+
 (setq org-static-blog-emfed-comments-block 
       "<div id=\"comments\"><h2>Comments<h2></div>
        <a class=\"mastodon-thread\" target=\"_blank\"

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -161,6 +161,15 @@ per-tag RSS feeds."
   :type '(string)
   :safe t)
 
+(defcustom org-static-blog-mastodon-comments-block ""
+  "HTML to put after the content (but before the 'postamble')
+that will contain an Emfed (https://sampsyo.github.io/emfed/)
+link to a Mastodon post for comments.
+
+Note: the key %s in this string will be expanded in the
+exported HTML to the contents of the #+masto-id: header."
+  :type '(string))
+ 
 (defcustom org-static-blog-page-postamble ""
   "HTML to put after the content of each page."
   :type '(string)
@@ -400,13 +409,7 @@ Only if og tags are enabled. It can be overridden with the
    tContent
    "</div>\n"
    (when tMasto-id
-     (format "<div id=\"comments\"><h2>Comments<h2></div>
-                   <a class=\"mastodon-thread\" target=\"_blank\"
-                      href=\"https://emacs.ch/@jameshowell/%s\"
-                      data-toot-id=\"%s\"
-                      data-exclude-post=\"true\"
-                   >Turn on JavaScript to view comments, or follow this link to the Mastodon thread</a>
-                <p>You can <a target=\"_blank\" href=\"https://emacs.ch/@jameshowell/%s\">add a comment on Mastodon</a>.</p>" tMasto-id tMasto-id tMasto-id))
+     (format-spec org-static-blog-mastodon-comments-block `((?s . ,tMasto-id))))
    "<div id=\"postamble\" class=\"status\">"
    org-static-blog-page-postamble
    "</div>\n"

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -161,7 +161,7 @@ per-tag RSS feeds."
   :type '(string)
   :safe t)
 
-(defcustom org-static-blog-mastodon-comments-block ""
+(defcustom org-static-blog-emfed-comments-block ""
   "HTML to put after the content (but before the 'postamble')
 that will contain an Emfed (https://sampsyo.github.io/emfed/)
 link to a Mastodon post for comments.

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -1042,6 +1042,40 @@ choose."
             "#+masto-id: \n"
             )))
 
+
+
+(defcustom org-static-blog-mastodon-access-token "q7FypdsKcCFa1oqaNW21ioLkezCim1lh6EhF3CjKbSQ"
+  "User's Mastodon access token.")
+
+(defcustom org-static-blog-mastodon-server "emacs.ch"
+  "User's Mastodon server.")
+
+(defun org-static-blog-create-mastodon-status (status-message)
+  "Post a new toot (\"status\") to Mastodon containing text
+STATUS-MESSAGE. Both `org-static-blog-mastodon-server' and
+`org-static-blog-mastodon-access-token' must be set appropriately.
+This function returns:
+
+- nil if posting fails
+- the Mastodon ID if posting succeeds."
+  (shell-command (concat "curl -s "    ;;; "silent," no progress bar
+                         "https://"
+                         org-static-blog-mastodon-server
+                         "/api/v1/statuses -H 'Authorization: Bearer "
+                         org-static-blog-mastodon-access-token
+                         "' -F 'status=" status-message "'")
+                 "*curl-output*" "*curl-errors*")
+  (let ((curl-output (with-current-buffer "*curl-output*" (buffer-string))))
+    (if (string= curl-output "")
+        (progn
+          (message "org-static-blog-create-mastodon-status: curl output was a null string")
+          nil)
+      (string-match "[0-9]\\{18\\}" curl-output)
+      (match-string 0 curl-output))))
+
+;;; (org-static-blog-create-mastodon-status "Testing: https://example.com")
+
+
 ;;;###autoload
 (defun org-static-blog-create-new-draft ()
   "Creates a new blog draft.

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -1039,7 +1039,6 @@ choose."
             "#+date: " (format-time-string "<%Y-%m-%d %H:%M>") "\n"
             "#+description: \n"
             "#+filetags: \n"
-            "#+masto-id: \n"
             )))
 
 
@@ -1050,30 +1049,51 @@ choose."
 (defcustom org-static-blog-mastodon-server "emacs.ch"
   "User's Mastodon server.")
 
-(defun org-static-blog-create-mastodon-status (status-message)
-  "Post a new toot (\"status\") to Mastodon containing text
-STATUS-MESSAGE. Both `org-static-blog-mastodon-server' and
-`org-static-blog-mastodon-access-token' must be set appropriately.
-This function returns:
+;; (defun org-static-blog-create-mastodon-status (status-message)
+;;   "Post a new toot (\"status\") to Mastodon containing text
+;; STATUS-MESSAGE. Both `org-static-blog-mastodon-server' and
+;; `org-static-blog-mastodon-access-token' must be set appropriately.
+;; This function returns:
 
-- nil if posting fails
-- the Mastodon ID if posting succeeds."
-  (shell-command (concat "curl -s "    ;;; "silent," no progress bar
-                         "https://"
-                         org-static-blog-mastodon-server
-                         "/api/v1/statuses -H 'Authorization: Bearer "
-                         org-static-blog-mastodon-access-token
-                         "' -F 'status=" status-message "'")
-                 "*curl-output*" "*curl-errors*")
-  (let ((curl-output (with-current-buffer "*curl-output*" (buffer-string))))
-    (if (string= curl-output "")
-        (progn
-          (message "org-static-blog-create-mastodon-status: curl output was a null string")
-          nil)
-      (string-match "[0-9]\\{18\\}" curl-output)
-      (match-string 0 curl-output))))
+;; - nil if posting fails
+;; - the Mastodon ID if posting succeeds."
+;;   (shell-command (concat "curl -s "    ;;; "silent," no progress bar
+;;                          "https://"
+;;                          org-static-blog-mastodon-server
+;;                          "/api/v1/statuses -H 'Authorization: Bearer "
+;;                          org-static-blog-mastodon-access-token
+;;                          "' -F 'status=" status-message "'")
+;;                  "*curl-output*" "*curl-errors*")
+;;   (let ((curl-output (with-current-buffer "*curl-output*" (buffer-string))))
+;;     (string-match "[0-9]\\{18\\}" curl-output)
+;;     (match-string 0 curl-output)))
 
-;;; (org-static-blog-create-mastodon-status "Testing: https://example.com")
+;; (with-current-buffer "*curl-output*"
+;;   (goto-char (point-min))
+;;   (if (string-match "waters" (buffer-string))
+;;       (match-string 1))
+
+
+;; (org-static-blog-create-mastodon-status
+;;  (concat "<div>New blog post: "
+;; 	  "Testing the waters</div>"
+;; 	  "https://example.com"))
+
+
+
+;; (defun org-static-blog-insert-mastodon-id (id)
+;;   "Insert the ID of a Mastodon status into the \"#+MASTO-ID\"
+;; header of an org-static-blog draft or post. It will be
+;; embedded via Emfed as comments."
+;;   )
+
+;; (org-static-blog-insert-mastodon-id 
+;;  (org-static-blog-create-mastodon-status
+;;   (concat "New blog post:"
+;; 	  --post-title
+;; 	  --newline
+;; 	  --post-url)))
+
 
 
 ;;;###autoload


### PR DESCRIPTION
Thanks so much for org-static-blog!

This is my _very first_ pull request on GitHub. I am a _complete beginner_ with GitHub, git, and Emacs lisp, so please bear with me and all the mistakes I make in technique and in etiquette! It's a measure of the clarity of the code that I was able to do anything with it.

[Emfed](https://sampsyo.github.io/emfed/) is a very simple way to embed a Mastodon feed. I just [posted an example at my own blog](https://jamesendreshowell.com/2024-08-17-my-first-blog-post.html). That page was produced with the minor changes represented in this pull request.

In short, I added a header #+MASTO-ID: represents the numerical identifier of the Mastodon post. That header gets parsed by 'org-static-blog-get-masto-id and the user's 'org-static-blog-emfed-comments-block gets inserted into the template.

The logic seems trivial, but I'm too new to know if it is submitted correctly in terms of style, or indeed if it is a useful addition to the package. If you find it useful but need me to add or change anything in order to accept it, I'm happy to do more (including changing the documentation and so forth).

Thanks for considering my submission.