### PR TITLE
Add another blog in README.org.

### DIFF
--- a/README.org
+++ b/README.org
@@ -204,6 +204,7 @@ your problem right now/. Please be civil.
     - [[https://xgqt.gitlab.io/blog/][xgqt.gitlab.io/blog]]
     - [[https://unmonoqueteclea.github.io/][unmonoqueteclea]]
     - [[https://chenyo-17.github.io/org-static-blog/][chenyo-17.github.io/org-static-blog]]
+    - [[https://dou-meishi.github.io/org-blog/][doumeishi.github.io/org-blog]] --- see the [[https://dou-meishi.github.io/org-blog/2024-01-22-TryOrgStaticBlog/notes.html][writeup]]
     - Please open a pull request to add your blog, here!
 
 ** Features
@@ -341,3 +342,4 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+


### PR DESCRIPTION
Hello, I have been using `org-static-blog` for a while and accumulated a decent number of [posts](https://dou-meishi.github.io/org-blog/), some of which were migrated from old templates. It is always a pleasure to share my thoughts on the internet with it. Thanks for your great work!
