### PR TITLE
Add optional Org Social feed generation

### DIFF
--- a/README.org
+++ b/README.org
@@ -62,6 +62,13 @@ For org-static-blog, a blog consists of six parts:
   title, the description and an optional image. If no =#+IMAGE= property
   is provided in a post, the default one specified in
   =org-static-blog-image= will be used.
+- If =org-static-blog-enable-social= is set to =t=, a =social.org= file
+  is generated following the [[https://github.com/tanrax/org-social][Org Social]] protocol. Each blog post
+  becomes a social entry with a preview and a link to the full
+  article, allowing the blog to participate in the Org Social
+  decentralized network. You can configure the feed metadata with
+  =org-static-blog-social-nick=, =org-static-blog-social-description=,
+  and =org-static-blog-social-avatar=.
 - To disable comments for single blog posts, reserve a tag name as
   =org-static-blog-no-comments-tag= and tag the post with that tag.
 - It is also possible to create per-tag RSS feeds.  This feature is
@@ -134,6 +141,9 @@ your problem right now/. Please be civil.
      (setq org-static-blog-posts-directory "~/projects/blog/posts/")
      (setq org-static-blog-drafts-directory "~/projects/blog/drafts/")
      (setq org-static-blog-enable-tags t)
+     (setq org-static-blog-enable-social t)
+     (setq org-static-blog-social-nick "staticblog")
+     (setq org-static-blog-social-description "My Static Org Blog on the Org Social network")
      (setq org-export-with-toc nil)
      (setq org-export-with-section-numbers nil)
 
@@ -315,6 +325,7 @@ the `/` will be replaced too and the suggested filename will be
   Makes whitespace cleaning of filename suggestions customizable (Thank you, Magnus Therning)
   Adds support for Open Graph meta tags (Thank you, Pablo González Carrizo)
   Various bugfixes (Thank you, Dou Meishi, Musa Al-hassy, Alexis Purslane, chenyo, Johnny5, Miao ZhiCheng)
+  Adds optional Org Social feed generation (Thank you, Andros Fenollosa)
 
 * LICENSE
 

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -151,6 +151,43 @@ existing tag.  The options `org-static-blog-rss-extra',
 per-tag RSS feeds."
   :type '(boolean))
 
+(defcustom org-static-blog-enable-social nil
+  "Whether to generate an Org Social file.
+When enabled, a `social.org' file is generated following the Org
+Social protocol (see URL `https://github.com/tanrax/org-social').
+Each blog post becomes a social post with a preview and a link to
+the full article."
+  :group 'org-static-blog
+  :type '(boolean)
+  :safe t)
+
+(defcustom org-static-blog-social-file "social.org"
+  "File name of the generated Org Social feed."
+  :type '(string)
+  :safe t)
+
+(defcustom org-static-blog-social-nick ""
+  "Nick for the Org Social feed.
+Must not contain spaces."
+  :type '(string)
+  :safe t)
+
+(defcustom org-static-blog-social-description ""
+  "Description for the Org Social feed."
+  :type '(string)
+  :safe t)
+
+(defcustom org-static-blog-social-avatar ""
+  "Avatar URL for the Org Social feed (JPG or PNG, 128x128+)."
+  :type '(string)
+  :safe t)
+
+(defcustom org-static-blog-social-max-entries nil
+  "Maximum number of entries in the Org Social feed.
+If nil (the default), all existing posts are included."
+  :type '(choice (const nil) integer)
+  :safe t)
+
 (defcustom org-static-blog-page-header ""
   "HTML to put in the <head> of each page."
   :type '(string)
@@ -437,7 +474,9 @@ unconditionally."
     (org-static-blog-assemble-rss)
     (org-static-blog-assemble-archive)
     (if org-static-blog-enable-tags
-        (org-static-blog-assemble-tags))))
+        (org-static-blog-assemble-tags))
+    (if org-static-blog-enable-social
+        (org-static-blog-assemble-social))))
 
 (defun org-static-blog-needs-publishing-p (post-filename)
   "Check whether POST-FILENAME was changed since last render."
@@ -957,6 +996,67 @@ blog post, sorted by tags, but no post body."
       (concat
        "<h1 class=\"title\">" (org-static-blog-gettext 'tags) "</h1>\n"
        (apply 'concat (mapcar 'org-static-blog-assemble-tags-archive-tag tag-tree)))))))
+
+(defun org-static-blog--date-to-rfc3339 (date)
+  "Convert an Emacs time value DATE to an RFC 3339 timestamp.
+Returns a string like 2025-01-08T13:58:00+0100."
+  (format-time-string "%Y-%m-%dT%H:%M:%S%z" date))
+
+(defun org-static-blog-get-social-item (post-filename)
+  "Generate an Org Social post entry for POST-FILENAME.
+Returns a string with the post heading, properties and body."
+  (let ((date (org-static-blog-get-date post-filename))
+        (title (org-static-blog-get-title post-filename))
+        (tags (org-static-blog-get-tags post-filename))
+        (description (org-static-blog-get-description post-filename))
+        (url (org-static-blog-get-post-url post-filename)))
+    (concat
+     "** " (org-static-blog--date-to-rfc3339 date) "\n"
+     ":PROPERTIES:\n"
+     (when (and org-static-blog-langcode
+                (not (string-empty-p org-static-blog-langcode)))
+       (concat ":LANG: " org-static-blog-langcode "\n"))
+     (when tags
+       (concat ":TAGS: " (mapconcat #'identity tags " ") "\n"))
+     ":CLIENT: org-static-blog\n"
+     ":END:\n"
+     "\n"
+     (if description
+         (concat description "\n")
+       (concat title "\n"))
+     "\n"
+     "[[" url "][" title "]]\n")))
+
+(defun org-static-blog-assemble-social ()
+  "Assemble the Org Social feed file.
+The social.org file follows the Org Social protocol and contains
+every blog post as a social entry with a preview and link."
+  (let ((social-filename (concat-to-dir org-static-blog-publish-directory
+                                        org-static-blog-social-file))
+        (post-filenames (sort (org-static-blog-get-post-filenames)
+                              (lambda (x y)
+                                (time-less-p (org-static-blog-get-date y)
+                                             (org-static-blog-get-date x))))))
+    (when org-static-blog-social-max-entries
+      (setq post-filenames (seq-take post-filenames
+                                     org-static-blog-social-max-entries)))
+    (org-static-blog-with-find-file
+     social-filename
+     (concat
+      "#+TITLE: " org-static-blog-publish-title "\n"
+      "#+NICK: " org-static-blog-social-nick "\n"
+      (unless (string-empty-p org-static-blog-social-description)
+        (concat "#+DESCRIPTION: " org-static-blog-social-description "\n"))
+      (unless (string-empty-p org-static-blog-social-avatar)
+        (concat "#+AVATAR: " org-static-blog-social-avatar "\n"))
+      "#+LINK: " org-static-blog-publish-url "\n"
+      (when (and org-static-blog-langcode
+                 (not (string-empty-p org-static-blog-langcode)))
+        (concat "#+LANGUAGE: " org-static-blog-langcode "\n"))
+      "\n"
+      "* Posts\n"
+      (apply #'concat (mapcar #'org-static-blog-get-social-item
+                              post-filenames))))))
 
 (defun org-static-blog-open-previous-post ()
   "Opens previous blog post."

--- a/org-static-blog.el
+++ b/org-static-blog.el
@@ -163,28 +163,33 @@ the full article."
 
 (defcustom org-static-blog-social-file "social.org"
   "File name of the generated Org Social feed."
+  :group 'org-static-blog
   :type '(string)
   :safe t)
 
 (defcustom org-static-blog-social-nick ""
   "Nick for the Org Social feed.
 Must not contain spaces."
+  :group 'org-static-blog
   :type '(string)
   :safe t)
 
 (defcustom org-static-blog-social-description ""
   "Description for the Org Social feed."
+  :group 'org-static-blog
   :type '(string)
   :safe t)
 
 (defcustom org-static-blog-social-avatar ""
   "Avatar URL for the Org Social feed (JPG or PNG, 128x128+)."
+  :group 'org-static-blog
   :type '(string)
   :safe t)
 
 (defcustom org-static-blog-social-max-entries nil
   "Maximum number of entries in the Org Social feed.
 If nil (the default), all existing posts are included."
+  :group 'org-static-blog
   :type '(choice (const nil) integer)
   :safe t)
 


### PR DESCRIPTION
## Summary

This adds an optional sixth output type to org-static-blog: an [Org Social](https://github.com/tanrax/org-social) feed file (`social.org`).

[Org Social](https://github.com/tanrax/org-social) is a decentralized social network protocol where each user's identity and posts live in a single plain-text `social.org` file. By generating this file alongside the existing HTML, RSS and archive outputs, any org-static-blog site can participate in the Org Social network automatically.

The implementation follows the same pattern used by tags and RSS:

- A boolean toggle (`org-static-blog-enable-social`, default `nil`)
- A filename variable (`org-static-blog-social-file`, default `"social.org"`)
- Configuration variables for the feed metadata (`nick`, `description`, `avatar`)
- An `org-static-blog-assemble-social` function called from `org-static-blog-publish`

### New customization variables

| Variable | Default | Description |
|---|---|---|
| `org-static-blog-enable-social` | `nil` | Enable social.org generation |
| `org-static-blog-social-file` | `"social.org"` | Output filename |
| `org-static-blog-social-nick` | `""` | Nick for the feed (required by spec) |
| `org-static-blog-social-description` | `""` | Feed description |
| `org-static-blog-social-avatar` | `""` | Avatar URL |
| `org-static-blog-social-max-entries` | `nil` | Limit entries (nil = all) |

### Usage

```elisp
(setq org-static-blog-enable-social t)
(setq org-static-blog-social-nick "myblog")
(setq org-static-blog-social-description "My blog on the Org Social network")
```

Then `M-x org-static-blog-publish` generates `social.org` alongside the usual outputs.

### Generated format

Each blog post becomes an entry under `* Posts` with an RFC 3339 timestamp heading, a `:PROPERTIES:` drawer (LANG, TAGS, CLIENT), the post description, and a link to the full article. The file includes global metadata (`#+TITLE:`, `#+NICK:`, `#+LINK:`, `#+LANGUAGE:`, etc.) as required by the Org Social spec v1.6.